### PR TITLE
fix: use registry manifest digest (RepoDigests) instead of local image ID

### DIFF
--- a/src/registry_scanner.py
+++ b/src/registry_scanner.py
@@ -949,7 +949,16 @@ class MCRRegistryScanner:
             # Extract other manifest data
             layers_count = len(inspect_data.get("RootFS", {}).get("Layers", []))
             created_time = inspect_data.get("Created", "")
-            digest = inspect_data.get("Id", "")
+
+            # Get registry digest from RepoDigests (preferred) for platform-agnostic digest
+            # RepoDigests format: ["registry/repo@sha256:..."]
+            # Falls back to local image Id if RepoDigests not available
+            repo_digests = inspect_data.get("RepoDigests", [])
+            if repo_digests:
+                first_digest = repo_digests[0]
+                digest = first_digest.split("@")[-1] if "@" in first_digest else ""
+            else:
+                digest = inspect_data.get("Id", "")
 
             manifest_data = {
                 "size": image_size,  # Use docker images size or 0


### PR DESCRIPTION
## Summary

Use `RepoDigests` from `docker inspect` to get the platform-agnostic registry manifest digest instead of the platform-specific image config ID from `.Id` field.

## Problem

The nightly recommendations report was storing the platform-specific image config ID which:
- Differs from what users see on MCR registry pages
- Varies by platform (arm64 vs amd64) for the same image tag
- Cannot be used to reliably pin images across platforms

## Solution

Extract the digest from `RepoDigests` which contains the registry manifest digest matching what MCR shows.

```python
# Before
digest = inspect_data.get("Id", "")

# After
repo_digests = inspect_data.get("RepoDigests", [])
if repo_digests:
    first_digest = repo_digests[0]
    digest = first_digest.split("@")[-1] if "@" in first_digest else ""
else:
    digest = inspect_data.get("Id", "")
```

## Testing

- All 67 tests pass
- Verified with `docker inspect` on both arm64 (macOS) and amd64 (Linux) that `RepoDigests` returns the same digest matching MCR

Fixes #36
